### PR TITLE
Add "None" option to ClientApi

### DIFF
--- a/GLFW.NET/Enums/ClientApi.cs
+++ b/GLFW.NET/Enums/ClientApi.cs
@@ -36,6 +36,11 @@ namespace GLFW
 	public enum ClientApi
 	{
 		/// <summary>
+		///	No context
+		/// </summary>
+		None = 0x00000000,
+		
+		/// <summary>
 		///     OpenGL
 		/// </summary>
 		OpenGL = 0x00030001,


### PR DESCRIPTION
When creating a Vulkan instance, the window hint `GLFW_NO_API` can be used to avoid creating an OpenGL context. This commit just adds that to the ClientApi enum.