### PR TITLE
GetRequiredInstanceExtensions assumes a pointer size

### DIFF
--- a/GLFW.NET/Vulkan.cs
+++ b/GLFW.NET/Vulkan.cs
@@ -107,7 +107,7 @@ namespace GLFW
                 var offset = 0;
                 for (var i = 0; i < count; i++, offset += IntPtr.Size)
                 {
-                    var p = new IntPtr(Marshal.ReadInt32(ptr, offset));
+                    var p = Marshal.ReadIntPtr(ptr, offset);
                     extensions[i] = Marshal.PtrToStringAnsi(p);
                 }
             }


### PR DESCRIPTION
Hello. You might want to change this pointer retrieval call in your Vulkan.GetRequiredInstanceExtensions method. Your code makes it crash on 64-bit hardware, because it assumes the pointer size to be 32 bits. I can verify it crashes on a 64-bit Arch Linux installation, this change makes it work flawlessly.