### PR TITLE
Fixed call to Vulkan.CreateWindowSurface

### DIFF
--- a/GLFW.NET/Vulkan.cs
+++ b/GLFW.NET/Vulkan.cs
@@ -38,7 +38,7 @@ namespace GLFW
         /// <returns>VK_SUCCESS if successful, or a Vulkan error code if an error occurred.</returns>
         [DllImport(Glfw.LIBRARY, EntryPoint = "glfwCreateWindowSurface", CallingConvention = CallingConvention.Cdecl)]
         public static extern int
-            CreateWindowSurface(IntPtr vulkan, IntPtr window, IntPtr allocator, out IntPtr surface);
+            CreateWindowSurface(IntPtr vulkan, IntPtr window, IntPtr allocator, out ulong surface);
 
         /// <summary>
         ///     This function returns whether the specified queue family of the specified physical device supports presentation to


### PR DESCRIPTION
The Vulkan.CreateWindowSurface method sets the surface out parameter that needs to be ulong and not IntPtr (IntPtr does not work in x86 process).

Note that in Vulkan some objects use pointers (IntPtr) - those are: VkInstance, VkPhysicalDevice, VkDevice, VkQueue and VkCommandBuffer (they are defined as VK_DEFINE_HANDLE in vulkan_core.h). Other objects are defined as VK_DEFINE_NON_DISPATCHABLE_HANDLE (are only handles and not real pointers) and are always 64 bit so ulong should be used instead of IntPtr.