### PR TITLE
Fixes for multi-platform building and .net standard

### DIFF
--- a/GLFW.NET/GLFW.NETCore.csproj
+++ b/GLFW.NET/GLFW.NETCore.csproj
@@ -13,14 +13,4 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Update="glfw.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="glfw3.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
 </Project>

--- a/GLFW.NET/GLFW.NETCore.csproj
+++ b/GLFW.NET/GLFW.NETCore.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Company></Company>
+    <AssemblyName>GLFW.NETCore</AssemblyName>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Update="glfw.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="glfw3.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/GLFW.NET/GLFW.NETStandard.csproj
+++ b/GLFW.NET/GLFW.NETStandard.csproj
@@ -29,4 +29,7 @@
   <PropertyGroup Condition="'$(IsLinux)'=='true'">
     <DefineConstants>Linux</DefineConstants>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Update="StyleCop.Analyzers" Version="1.1.118" />
+  </ItemGroup>
 </Project>

--- a/GLFW.NET/GLFW.NETStandard.csproj
+++ b/GLFW.NET/GLFW.NETStandard.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Company></Company>
     <AssemblyName>GLFW.NETCore</AssemblyName>
+    <ReleaseVersion>2.20.12</ReleaseVersion>
+    <RootNamespace>GLFW.NETStandard</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/GLFW.NET/GLFW.NETStandard.csproj
+++ b/GLFW.NET/GLFW.NETStandard.csproj
@@ -6,6 +6,9 @@
     <AssemblyName>GLFW.NETStandard</AssemblyName>
     <ReleaseVersion>2.20.12</ReleaseVersion>
     <RootNamespace>GLFW.NETStandard</RootNamespace>
+    <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows>
+    <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
+    <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -14,5 +17,16 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <!-- support cross-platform glfw resolution -->
+  <PropertyGroup Condition="'$(IsWindows)'=='true'">
+    <DefineConstants>Windows</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(IsOSX)'=='true'">
+    <DefineConstants>OSX</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(IsLinux)'=='true'">
+    <DefineConstants>Linux</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/GLFW.NET/GLFW.NETStandard.csproj
+++ b/GLFW.NET/GLFW.NETStandard.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Company></Company>
-    <AssemblyName>GLFW.NETCore</AssemblyName>
+    <AssemblyName>GLFW.NETStandard</AssemblyName>
     <ReleaseVersion>2.20.12</ReleaseVersion>
     <RootNamespace>GLFW.NETStandard</RootNamespace>
   </PropertyGroup>

--- a/GLFW.NET/Glfw.cs
+++ b/GLFW.NET/Glfw.cs
@@ -22,8 +22,8 @@ namespace GLFW
         ///     <para>For Unix users using an installed version of GLFW, this needs refactored to <c>glfw</c>.</para>
         /// </summary>
         // public const string LIBRARY = "glfw3"; // linux
-        // public const string LIBRARY = "libglfw.3"; // mac
-        public const string LIBRARY = "glfw3"; // windows
+        public const string LIBRARY = "libglfw.3"; // mac
+        // public const string LIBRARY = "glfw3"; // windows
 
         private static readonly ErrorCallback errorCallback = GlfwError;
 

--- a/GLFW.NET/Glfw.cs
+++ b/GLFW.NET/Glfw.cs
@@ -21,9 +21,13 @@ namespace GLFW
         ///     The native library name,
         ///     <para>For Unix users using an installed version of GLFW, this needs refactored to <c>glfw</c>.</para>
         /// </summary>
-        // public const string LIBRARY = "glfw3"; // linux
+#if Windows
+        public const string LIBRARY = "glfw3";
+#elif OSX
         public const string LIBRARY = "libglfw.3"; // mac
-        // public const string LIBRARY = "glfw3"; // windows
+#else
+        public const string LIBRARY = "glfw";
+#endif
 
         private static readonly ErrorCallback errorCallback = GlfwError;
 

--- a/GLFW.NET/Glfw.cs
+++ b/GLFW.NET/Glfw.cs
@@ -21,7 +21,9 @@ namespace GLFW
         ///     The native library name,
         ///     <para>For Unix users using an installed version of GLFW, this needs refactored to <c>glfw</c>.</para>
         /// </summary>
-        public const string LIBRARY = "glfw";
+        // public const string LIBRARY = "glfw3"; // linux
+        // public const string LIBRARY = "libglfw.3"; // mac
+        public const string LIBRARY = "glfw3"; // windows
 
         private static readonly ErrorCallback errorCallback = GlfwError;
 

--- a/GLFW.NET/Util.cs
+++ b/GLFW.NET/Util.cs
@@ -19,12 +19,17 @@ namespace GLFW
         // ReSharper disable once InconsistentNaming
         public static string PtrToStringUTF8(IntPtr ptr)
         {
-            var length = 0;
-            while (Marshal.ReadByte(ptr, length) != 0)
-                length++;
-            var buffer = new byte[length];
-            Marshal.Copy(ptr, buffer, 0, length);
-            return Encoding.UTF8.GetString(buffer);
+            if (ptr != IntPtr.Zero)
+            {
+                var length = 0;
+                while (Marshal.ReadByte(ptr, length) != 0)
+                    length++;
+                var buffer = new byte[length];
+                Marshal.Copy(ptr, buffer, 0, length);
+                return Encoding.UTF8.GetString(buffer);
+            }
+
+            return "";
         }
 
         #endregion


### PR DESCRIPTION
Added a project to build for .net standard
fixed crash when decoding a null string from GetKeyName (returns null for some characters on mac)